### PR TITLE
Virtual shouldn't be used when declaring an override.

### DIFF
--- a/Modulate/CDtaFile.h
+++ b/Modulate/CDtaFile.h
@@ -132,7 +132,7 @@ public:
         mbIsBaseNode = false;
     }
 
-    virtual void SaveToStream( unsigned char*& lpStream ) const override { }
+    void SaveToStream( unsigned char*& lpStream ) const override { }
 
     const T& GetValue() const
     {


### PR DESCRIPTION
Declaring a function as an "override" makes "virtual" be useless. Removing "virtual" can help prevent any issues with Inheritance.