### PR TITLE
Ignore special keys for charter and demo video

### DIFF
--- a/Modulate/CDtaFile.cpp
+++ b/Modulate/CDtaFile.cpp
@@ -1290,6 +1290,9 @@ eError CMoggsong::ProcessMoggSongKey( char*& lpData, __int64 liDataSize )
     READ_FLOAT( "bpm", mfBPM );
 
 #define IGNORE_KEY( lpName ) if( IS_KEY( lpName ) ) { std::string lIgnore; return lReadString( lIgnore ); }
+    
+    IGNORE_KEY( "charter" );
+    IGNORE_KEY( "demo_video" );
 
     std::cout << "Unknown token in file: " << lpData << "\n";
 


### PR DESCRIPTION
Ignore moggsong keys for `charter` and `demo_video`.

These aren't used in-game, but they are intended to be used as metadata for custom tracks.