### PR TITLE
Set header checksum count

### DIFF
--- a/Modulate/CArk.cpp
+++ b/Modulate/CArk.cpp
@@ -916,6 +916,7 @@ eError CArk::SaveArk( const char* lpOutputDirectory, const char* lpHeaderFilenam
 
         unsigned char* lpHeaderPtr = lacHeaderData + ( 1 * sizeof( unsigned int ) );
         sHeaderBase* lpHeaderBase = (sHeaderBase*)lpHeaderPtr;
+        lpHeaderBase->miNumChecksums = 1;
         lpHeaderBase->muVersion = kuUnencryptedVersion;
         lpHeaderBase->miNumArks = miNumArks;
 

--- a/Modulate/CArk.h
+++ b/Modulate/CArk.h
@@ -26,7 +26,8 @@ public:
 private:
     struct sHeaderBase {
         unsigned int muVersion;
-        char mChecksumData[ 20 ];
+        unsigned int miNumChecksums;
+        char mChecksumData[ 16 ];
         int miNumArks;
     };
     struct sIntList {


### PR DESCRIPTION
This makes no difference to modulate or the game, but they are 16-byte headers with a 32-bit count before the data.

This does however make a difference in other tools that deal with ark files because by setting the count to 0, it results in the file position not being moved forward even though there is a "hash" in the header modulate creates.